### PR TITLE
Subtract 1 from the rows and columns that come from gometalinter

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -193,9 +193,9 @@ class GometalinterLinter {
     for (let message of messages) {
       let range
       if (message.col && message.col >= 0) {
-        range = [[message.line, message.col], [message.line, message.col]]
+        range = [[message.line-1, message.col-1], [message.line-1, message.col-1]]
       } else {
-        range = [[message.line, 0], [message.line, 0]]
+        range = [[message.line-1, 0], [message.line-1, 0]]
       }
       results.push({name: message.linter, type: message.severity, row: message.line, column: message.col, text: message.message + ' (' + message.linter + ')', filePath: path.join(cwd, message.path), range: range})
     }


### PR DESCRIPTION
gometalinter outputs rows and columns starting with (1, 1), but Atom internally uses (0, 0) as the first point of the file.

Fixes #16.
